### PR TITLE
Use GMP factor removal for decimals

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,8 +1,26 @@
 use {
   criterion::{Criterion, criterion_group, criterion_main},
+  rug::{Integer, Rational},
   std::hint::black_box,
-  val::{Environment, Evaluator},
+  val::{Config, Environment, Evaluator, Number},
 };
+
+fn bench_decimal_display(criterion: &mut Criterion) {
+  let mut group = criterion.benchmark_group("decimal_display");
+
+  for &(factor, exponent) in &[(2, 100), (2, 1_000), (5, 100), (5, 1_000)] {
+    let mut denominator = Integer::from(Integer::u_pow_u(factor, exponent));
+    denominator *= 3;
+
+    let number = Number::Exact(Rational::from((1, denominator)));
+
+    group.bench_function(format!("3 * {factor}^{exponent}"), |bencher| {
+      bencher.iter(|| black_box(number.display(Config::default())));
+    });
+  }
+
+  group.finish();
+}
 
 fn bench_increment_value(criterion: &mut Criterion) {
   let mut group = criterion.benchmark_group("increment_value");
@@ -104,6 +122,7 @@ fn bench_recursive_factorial(criterion: &mut Criterion) {
 
 criterion_group!(
   benches,
+  bench_decimal_display,
   bench_increment_value,
   bench_prime_count,
   bench_recursive_factorial

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -64,10 +64,15 @@ impl Decimal {
   pub(crate) fn from_rational(number: &Rational) -> Option<Self> {
     let mut denominator = number.denom().clone();
 
-    let (twos, fives) = (
-      Self::remove_factor(&mut denominator, 2),
-      Self::remove_factor(&mut denominator, 5),
-    );
+    let twos = usize::try_from(
+      denominator.remove_factor_mut(&MiniInteger::from(2).borrow()),
+    )
+    .unwrap();
+
+    let fives = usize::try_from(
+      denominator.remove_factor_mut(&MiniInteger::from(5).borrow()),
+    )
+    .unwrap();
 
     if denominator != 1 {
       return None;
@@ -108,17 +113,6 @@ impl Decimal {
       negative,
       point,
     }
-  }
-
-  fn remove_factor(number: &mut Integer, factor: u32) -> usize {
-    let mut count = 0;
-
-    while number.is_divisible_u(factor) {
-      *number /= factor;
-      count += 1;
-    }
-
-    count
   }
 
   fn scientific_string(&self, exponent: i64) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use {
   rug::{
     Complete, Float, Integer, Rational,
     float::{Constant, Round},
+    integer::MiniInteger,
     ops::Pow,
   },
   std::{


### PR DESCRIPTION
Replaces repeated factor-removal loops in decimal conversion with GMP-backed `remove_factor_mut`. Stack-backed `MiniInteger` factors avoid additional heap allocations.

Criterion results for non-terminating denominators with large powers of 2 and 5:

| Denominator | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `3 * 2^100` | 2.00 us | 636 ns | 3.1x |
| `3 * 2^1000` | 36.0 us | 698 ns | 51.6x |
| `3 * 5^100` | 3.85 us | 1.07 us | 3.6x |
| `3 * 5^1000` | 181 us | 2.93 us | 61.7x |