### PR TITLE
Keep Completion internal

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub enum Completion {
+pub(crate) enum Completion {
   Break,
   Continue,
   Return(Value),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use {
   ariadne::{Color, IndexType, Label, Report, ReportKind},
   ast::{AssignmentTarget, BinaryOp, Expression, Program, Statement, UnaryOp},
   chumsky::prelude::*,
+  completion::Completion,
   context::Context,
   decimal::Decimal,
   frame::Frame,
@@ -27,11 +28,10 @@ use {
 pub use crate::{
   builtin::Builtin, builtin_arity::BuiltinArity,
   builtin_function::BuiltinFunction,
-  builtin_function_payload::BuiltinFunctionPayload, completion::Completion,
-  config::Config, environment::Environment, error::Error,
-  evaluation::Evaluation, evaluator::Evaluator, function::Function,
-  number::Number, parser::parse, rounding_mode::RoundingMode,
-  user_function::UserFunction, value::Value,
+  builtin_function_payload::BuiltinFunctionPayload, config::Config,
+  environment::Environment, error::Error, evaluation::Evaluation,
+  evaluator::Evaluator, function::Function, number::Number, parser::parse,
+  rounding_mode::RoundingMode, user_function::UserFunction, value::Value,
 };
 
 pub type Result<T = (), E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
`Completion` is only used to propagate control flow within the evaluator and user-defined functions. Make it crate-private and replace its public re-export with a private root import.

Validation: all 260 workspace tests passed; workspace Clippy with warnings denied, formatting, and `bin/forbid` passed.
