### PR TITLE
Simplify AST representation

### DIFF
--- a/crates/val-wasm/src/ast_node.rs
+++ b/crates/val-wasm/src/ast_node.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Clone, Serialize)]
 pub struct AstNode {
-  pub kind: String,
+  pub kind: &'static str,
   pub range: Range,
   pub children: Vec<AstNode>,
 }
@@ -25,12 +25,8 @@ impl From<(&Program, &Span)> for AstNode {
 
     let mut children = Vec::new();
 
-    match program {
-      Program::Statements(statements) => {
-        for (statement, span) in statements {
-          children.push(Self::from((statement, span)));
-        }
-      }
+    for (statement, span) in &program.statements {
+      children.push(Self::from((statement, span)));
     }
 
     Self {
@@ -192,10 +188,10 @@ mod tests {
     let converter = RangeConverter::new("é 😀");
 
     let mut node = AstNode {
-      kind: "foo".into(),
+      kind: "foo",
       range: Range { start: 0, end: 7 },
       children: vec![AstNode {
-        kind: "bar".into(),
+        kind: "bar",
         range: Range { start: 3, end: 7 },
         children: Vec::new(),
       }],

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,26 +1,24 @@
 use super::*;
 
 #[derive(Debug, Clone)]
-pub enum Program {
-  Statements(Vec<Spanned<Statement>>),
+pub struct Program {
+  pub statements: Vec<Spanned<Statement>>,
 }
 
 impl Program {
   #[must_use]
-  pub fn kind(&self) -> String {
-    String::from(match self {
-      Program::Statements(_) => "statements",
-    })
+  pub fn kind(&self) -> &'static str {
+    "statements"
   }
 }
 
 impl Display for Program {
   fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-    match self {
-      Program::Statements(statements) => {
-        write!(f, "statements({})", Statement::display_list(statements))
-      }
-    }
+    write!(
+      f,
+      "statements({})",
+      Statement::display_list(&self.statements)
+    )
   }
 }
 
@@ -53,8 +51,8 @@ impl Statement {
   }
 
   #[must_use]
-  pub fn kind(&self) -> String {
-    String::from(match self {
+  pub fn kind(&self) -> &'static str {
+    match self {
       Statement::Assignment(_, _) => "assignment",
       Statement::Block(_) => "block",
       Statement::Break => "break",
@@ -66,7 +64,7 @@ impl Statement {
       Statement::Loop(_) => "loop",
       Statement::Return(_) => "return",
       Statement::While(_, _) => "while",
-    })
+    }
   }
 }
 
@@ -147,11 +145,11 @@ pub enum AssignmentTarget {
 
 impl AssignmentTarget {
   #[must_use]
-  pub fn kind(&self) -> String {
-    String::from(match self {
+  pub fn kind(&self) -> &'static str {
+    match self {
       AssignmentTarget::Identifier(_) => "identifier",
       AssignmentTarget::ListAccess(_, _) => "list_access",
-    })
+    }
   }
 }
 
@@ -259,8 +257,8 @@ pub enum Expression {
 
 impl Expression {
   #[must_use]
-  pub fn kind(&self) -> String {
-    String::from(match self {
+  pub fn kind(&self) -> &'static str {
+    match self {
       Expression::BinaryOp(_, _, _) => "binary_op",
       Expression::Boolean(_) => "boolean",
       Expression::Function(_, _) => "function",
@@ -272,7 +270,7 @@ impl Expression {
       Expression::Number(_) => "number",
       Expression::String(_) => "string",
       Expression::UnaryOp(_, _) => "unary_op",
-    })
+    }
   }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -96,14 +96,12 @@ impl Evaluator {
   pub fn evaluate(&mut self, ast: &Spanned<Program>) -> Result<Evaluation> {
     let (node, _) = ast;
 
-    let result = match node {
-      Program::Statements(statements) => self
-        .evaluate_statements(statements)
-        .map(|completion| match completion {
-          Completion::Return(value) | Completion::Value(value) => value,
-          Completion::Break | Completion::Continue => Value::Null,
-        }),
-    };
+    let result = self
+      .evaluate_statements(&node.statements)
+      .map(|completion| match completion {
+        Completion::Return(value) | Completion::Value(value) => value,
+        Completion::Break | Completion::Continue => Value::Null,
+      });
 
     match result {
       Ok(value) => Ok(Evaluation::Value(value)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,7 +31,7 @@ fn program_parser<'a>()
   padding_parser()
     .ignore_then(statement_list_parser(statement_parser()))
     .then_ignore(padding_parser())
-    .map(Program::Statements)
+    .map(|statements| Program { statements })
     .map_with(|ast, error| (ast, error.span()))
 }
 


### PR DESCRIPTION
The AST represents a program with a single-variant enum and returns owned strings for fixed kind labels. Replace `Program::Statements` with `Program { statements }` and return `&'static str` from every AST `kind()` method.

Update parsing, evaluation, and the WebAssembly AST view to use the simpler types while preserving AST display output and the serialized tree shape.

Validation: all 260 workspace tests passed; workspace Clippy with warnings denied, formatting, and `bin/forbid` passed. The `wasm32-unknown-unknown` check also passed using the installed rustup compiler.
